### PR TITLE
Add initial quiz support to backend.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1076,6 +1076,21 @@
         "@types/node": "*"
       }
     },
+    "@types/domhandler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.1.tgz",
+      "integrity": "sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA==",
+      "dev": true
+    },
+    "@types/domutils": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@types/domutils/-/domutils-1.7.2.tgz",
+      "integrity": "sha512-Nnwy1Ztwq42SSNSZSh9EXBJGrOZPR+PQ2sRT4VZy8hnsFXfCil7YlKO2hd2360HyrtFz2qwnKQ13ENrgXNxJbw==",
+      "dev": true,
+      "requires": {
+        "@types/domhandler": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1109,6 +1124,17 @@
       "integrity": "sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==",
       "optional": true,
       "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@types/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-fCxmHS4ryCUCfV9+CJZY1UjkbR+6Al/EQdX5Jh03qBj9gdlPG5q+7uNoDgE/ZNXb3XNWSAQgqKIWnbRCbOyyWA==",
+      "dev": true,
+      "requires": {
+        "@types/domhandler": "*",
+        "@types/domutils": "*",
         "@types/node": "*"
       }
     },
@@ -1165,6 +1191,15 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
+    },
+    "@types/sanitize-html": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-1.20.2.tgz",
+      "integrity": "sha512-SrefiiBebGIhxEFkpbbYOwO1S6+zQLWAC4s4tipchlHq1aO9bp0xiapM7Zm0ml20MF+3OePWYdksB1xtneKPxg==",
+      "dev": true,
+      "requires": {
+        "@types/htmlparser2": "*"
+      }
     },
     "@types/serve-static": {
       "version": "1.13.3",
@@ -1418,7 +1453,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1470,6 +1504,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.3.2",
@@ -1907,7 +1946,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1918,7 +1956,6 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -2034,7 +2071,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2042,8 +2078,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2442,6 +2477,32 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        },
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -2449,6 +2510,23 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -2549,6 +2627,11 @@
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
       "optional": true
     },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2617,8 +2700,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.1",
@@ -3560,8 +3642,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -3676,6 +3757,19 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
       "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
       "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -6053,6 +6147,16 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "optional": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+    },
     "lodash.has": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
@@ -6088,6 +6192,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -6433,6 +6542,11 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -6785,6 +6899,16 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcss": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+      "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6965,6 +7089,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "quill-delta-to-html": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/quill-delta-to-html/-/quill-delta-to-html-0.11.0.tgz",
+      "integrity": "sha512-PsW/VIuVDxa0xN/e+jglsSZy2eSUl/db3Lbvv3uC/syFi2ZIBL8zSsQfR7qrURrt4Aih36JZnw37CFxelIaX2Q=="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7028,7 +7157,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "optional": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7480,6 +7608,23 @@
         }
       }
     },
+    "sanitize-html": {
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.21.1.tgz",
+      "integrity": "sha512-W6enXSVphVaVbmVbzVngBthR5f5sMmhq3EfPfBlzBzp2WnX8Rnk7NGpP7KmHUc0Y3MVk9tv/+CbpdHchX9ai7g==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "htmlparser2": "^3.10.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mergewith": "^4.6.1",
+        "postcss": "^7.0.5",
+        "srcset": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
     "saxes": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
@@ -7765,8 +7910,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -7849,6 +7993,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "srcset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+      "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
+      "requires": {
+        "array-uniq": "^1.0.2",
+        "number-is-nan": "^1.0.0"
+      }
     },
     "sshpk": {
       "version": "1.16.1",
@@ -7968,7 +8121,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "optional": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -8016,7 +8168,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
       "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -8506,8 +8657,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "optional": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.2",
+    "@types/sanitize-html": "^1.20.2",
     "@types/validator": "^12.0.1",
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
@@ -30,6 +31,8 @@
     "express": "^4.17.1",
     "firebase-admin": "^8.9.2",
     "http-status-codes": "^1.4.0",
+    "quill-delta-to-html": "^0.11.0",
+    "sanitize-html": "^1.21.1",
     "validator": "^12.2.0"
   }
 }

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -28,12 +28,3 @@ export class ApiError extends Error {
     return new ApiError(message, Status.BAD_REQUEST);
   }
 }
-
-// This type represents all valid json.
-export type json =
-  | string
-  | number
-  | boolean
-  | null
-  | json[]
-  | { [key in string | number]: json };

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,3 +1,5 @@
 import * as admin from "firebase-admin";
 
-export default admin.initializeApp();
+export default admin.initializeApp({
+  projectId: process.env.FIREBASE_PROJECT_ID
+});

--- a/src/v1/model.ts
+++ b/src/v1/model.ts
@@ -1,0 +1,22 @@
+// This type represents all valid json.
+export type json =
+  | string
+  | number
+  | boolean
+  | null
+  | json[]
+  | { [key in string | number]: json };
+
+export type Json =
+  | { toJSON(): Json | json }
+  | { [key in string | number]: Json | json }
+  | Json[];
+
+export abstract class Model {
+  abstract toJSON(): json | Json;
+  abstract toDatastore(): json;
+
+  static fromDatastore(id: string, json: json): unknown {
+    return null;
+  }
+}

--- a/src/v1/quiz/db.ts
+++ b/src/v1/quiz/db.ts
@@ -1,9 +1,55 @@
 import { V1DB } from "../db";
 
+import { Quiz, isQuizDocument } from "./models/quiz";
+import { isAnswerDocument, AnswerDoc, Answer } from "./models/answer";
+import { isQuestionDocument, Question } from "./models/question";
+
 export class QuizDB {
   private db: V1DB;
 
   constructor(db: V1DB) {
     this.db = db;
+  }
+
+  async getQuiz(id: string): Promise<Quiz> {
+    const quizDoc = await this.db.quiz().doc(id);
+
+    const quizData = await quizDoc.get();
+    const questionCollection = await quizDoc
+      .collection("questions")
+      .listDocuments();
+
+    const unresolvedQuestions = questionCollection.map(async d => {
+      const questionDoc = await d.get();
+
+      if (!isQuestionDocument(questionDoc)) {
+        throw new Error("Invalid question in quiz!");
+      }
+
+      const answerData = await d.collection("answers").get();
+
+      const answers = answerData.docs
+        .filter((d): d is FirebaseFirestore.QueryDocumentSnapshot<AnswerDoc> =>
+          isAnswerDocument(d)
+        )
+        .map(d => Answer.fromDatastore(d.id, d.data()));
+
+      const question = Question.fromDatastore(
+        questionDoc.id,
+        questionDoc.data()
+      )(answers);
+
+      return question;
+    });
+
+    const questions = await Promise.all(unresolvedQuestions);
+
+    if (isQuizDocument(quizData)) {
+      const quiz = Quiz.fromDatastore(quizData.id, quizData.data())(questions);
+
+      return quiz;
+    } else {
+      throw new Error("Invalid quiz!");
+    }
   }
 }

--- a/src/v1/quiz/models/answer.ts
+++ b/src/v1/quiz/models/answer.ts
@@ -1,0 +1,42 @@
+import { Model } from "../../model";
+
+import { RichText, RichTextData, isRichTextData } from "./richtext";
+
+export type AnswerId = string;
+export type AnswerDoc = {
+  text: RichTextData;
+};
+
+export function isAnswerDocument(
+  doc: FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>
+): doc is FirebaseFirestore.DocumentSnapshot<AnswerDoc> {
+  const asQuiz = doc as FirebaseFirestore.DocumentSnapshot<AnswerDoc>;
+  const data = asQuiz.data();
+  return data.text && isRichTextData(data.text);
+}
+
+export class Answer extends Model {
+  id: AnswerId;
+  text: RichText;
+
+  toJSON() {
+    const { id, text } = this;
+    return {
+      id,
+      text
+    };
+  }
+
+  static fromDatastore(id: string, doc: AnswerDoc): Answer {
+    const answer = new Answer();
+    answer.id = id;
+    answer.text = RichText.fromDatastore(doc.text);
+    return answer;
+  }
+
+  toDatastore(): AnswerDoc {
+    return {
+      text: this.text.toDatastore()
+    };
+  }
+}

--- a/src/v1/quiz/models/question.ts
+++ b/src/v1/quiz/models/question.ts
@@ -60,9 +60,10 @@ export class Question extends Model {
   }
 
   toJSON() {
-    const { body, header, answers } = this;
+    const { id, body, header, answers } = this;
 
     return {
+      id,
       body,
       header,
       answers

--- a/src/v1/quiz/models/question.ts
+++ b/src/v1/quiz/models/question.ts
@@ -1,0 +1,71 @@
+import { Model } from "../../model";
+
+import { RichText, RichTextData, isRichTextData } from "./richtext";
+import { Answer, AnswerId } from "./answer";
+
+export type QuestionId = string;
+export type QuestionDoc = {
+  correctAnswer: string;
+  body: RichTextData;
+  header: RichTextData;
+};
+
+export function isQuestionDocument(
+  doc: FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>
+): doc is FirebaseFirestore.DocumentSnapshot<QuestionDoc> {
+  const asQuiz = doc as FirebaseFirestore.DocumentSnapshot<QuestionDoc>;
+  const data = asQuiz.data();
+
+  const hasBody = data.body && isRichTextData(data.body);
+  const hasHeader = data.header && isRichTextData(data.header);
+
+  return hasBody && hasHeader;
+}
+
+export class Question extends Model {
+  id: QuestionId;
+  body: RichText;
+  header: RichText;
+
+  answers: Answer[];
+  correctAnswer: AnswerId;
+
+  toDatastore(): QuestionDoc {
+    return {
+      correctAnswer: `${this.correctAnswer}`,
+      body: this.body.toDatastore(),
+      header: this.header.toDatastore()
+    };
+  }
+
+  getAnswers(): Answer[] {
+    return this.answers;
+  }
+
+  static fromDatastore(
+    id: string,
+    data: QuestionDoc
+  ): (answers: Answer[]) => Question {
+    return (answers: Answer[]) => {
+      const q = new Question();
+
+      q.id = id;
+      q.answers = answers;
+      q.body = RichText.fromDatastore(data.body);
+      q.header = RichText.fromDatastore(data.header);
+      q.correctAnswer = data.correctAnswer;
+
+      return q;
+    };
+  }
+
+  toJSON() {
+    const { body, header, answers } = this;
+
+    return {
+      body,
+      header,
+      answers
+    };
+  }
+}

--- a/src/v1/quiz/models/quiz.ts
+++ b/src/v1/quiz/models/quiz.ts
@@ -1,0 +1,53 @@
+import { Model } from "../../model";
+
+import { Question, QuestionDoc } from "./question";
+
+export type QuizId = string;
+export type QuizDoc = {
+  name: string;
+  questions: QuestionDoc[];
+};
+
+export function isQuizDocument(
+  doc: FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>
+): doc is FirebaseFirestore.DocumentSnapshot<QuizDoc> {
+  const asQuiz = doc as FirebaseFirestore.DocumentSnapshot<QuizDoc>;
+  const data = asQuiz.data();
+
+  return data && "name" in data && typeof data.name === "string";
+}
+
+export class Quiz extends Model {
+  id: QuizId;
+  name: string;
+  questions: Question[];
+
+  toJSON() {
+    const { id, questions, name } = this;
+    return {
+      id,
+      name,
+      questions
+    };
+  }
+
+  static fromDatastore(
+    id: string,
+    quizDoc: QuizDoc
+  ): (questions: Question[]) => Quiz {
+    const { name } = quizDoc;
+
+    return (questions: Question[]) => {
+      const quiz = new Quiz();
+      quiz.id = id;
+      quiz.questions = questions;
+      quiz.name = name;
+      return quiz;
+    };
+  }
+
+  toDatastore() {
+    const { name } = this;
+    return { name };
+  }
+}

--- a/src/v1/quiz/models/richtext.ts
+++ b/src/v1/quiz/models/richtext.ts
@@ -1,0 +1,70 @@
+import { QuillDeltaToHtmlConverter } from "quill-delta-to-html";
+import sanitize from "sanitize-html";
+
+export type RichTextData = {
+  delta: string;
+  rendered: string;
+  sanitized: string;
+};
+
+export function isRichTextData(data: unknown) {
+  if (typeof data !== "object") {
+    return false;
+  }
+
+  const asRTD = data as RichTextData;
+
+  return (
+    typeof asRTD.delta === "string" &&
+    typeof asRTD.rendered === "string" &&
+    typeof asRTD.sanitized === "string"
+  );
+}
+
+export class RichText { // This isn't technically a "model" (it isn't a document)
+  private delta: string;
+  private rendered: string;
+  private sanitized: string;
+
+  fromJSON(delta: string) {
+    const rt = new RichText();
+    rt.delta = delta;
+
+    // We'll start with a quite restrictive subset of HTML.
+    const opts = {
+      allowedTags: ["b", "i", "em", "strong", "a"],
+      allowedAttributes: {
+        a: ["href"]
+      }
+    };
+
+    // render the text.
+    const converter = new QuillDeltaToHtmlConverter(JSON.parse(delta), {});
+    const unsanitizedHtml = converter.convert();
+
+    const sanitizedHtml = sanitize(unsanitizedHtml, opts);
+
+    rt.rendered = unsanitizedHtml;
+    rt.sanitized = sanitizedHtml;
+
+    return rt;
+  }
+
+  toJSON() {
+    return this.sanitized;
+  }
+
+  toDatastore() {
+    const { delta, rendered, sanitized } = this;
+
+    return { delta, rendered, sanitized };
+  }
+
+  static fromDatastore(data: RichTextData) {
+    const rt = new RichText();
+    rt.delta = data.delta;
+    rt.rendered = data.rendered;
+    rt.sanitized = data.sanitized;
+    return rt;
+  }
+}

--- a/src/v1/quiz/routes.ts
+++ b/src/v1/quiz/routes.ts
@@ -1,14 +1,31 @@
 import * as express from "express";
 import * as Status from "http-status-codes";
 
-import { QuizDB } from "./db";
+import { asyncify } from "../../middleware/async";
 
 import { V1DB } from "../db";
+
+import { QuizDB } from "./db";
 
 export default function defineRoutes(db: V1DB): express.Router {
   const router = express.Router();
 
   const quizdb = new QuizDB(db);
+
+  router.get(
+    "/:id",
+    asyncify(async (req, res) => {
+      const { id } = req.params;
+
+      const quiz = await quizdb.getQuiz(id);
+
+      if (quiz) {
+        res.status(Status.OK).send(quiz.toJSON());
+      } else {
+        res.status(Status.NOT_FOUND).send({ message: "Quiz does not exist!" });
+      }
+    })
+  );
 
   return router;
 }

--- a/src/v1/quiz/routes.ts
+++ b/src/v1/quiz/routes.ts
@@ -27,5 +27,42 @@ export default function defineRoutes(db: V1DB): express.Router {
     })
   );
 
+  router.get(
+    "/:quizId/question/:questionId/verify-answer/:answerId",
+    asyncify(async (req, res) => {
+      const { quizId, questionId, answerId } = req.params;
+
+      const question = await quizdb.getQuestion(quizId, questionId, false);
+
+      if (question) {
+        const correct = question.correctAnswer === answerId;
+
+        // TODO Allow the message to be dynamic.
+
+        if (correct) {
+          res.status(Status.OK).send({
+            quizId,
+            questionId,
+            answerId,
+            correct,
+            message: "Congrats!"
+          });
+        } else {
+          res.status(Status.OK).send({
+            quizId,
+            questionId,
+            answerId,
+            correct,
+            message: "Whoops try again!"
+          });
+        }
+      } else {
+        res
+          .status(Status.NOT_FOUND)
+          .send({ message: "Question does not exist!" });
+      }
+    })
+  );
+
   return router;
 }


### PR DESCRIPTION
Addresses #3.

- [X] Send basic quiz content.
- [ ] Send quiz "ordering"
- [ ] Add endpoint for answer validation.
- [ ] Finish defining all quiz-related models.

Currently assumes the admin panel will use [Quill.js](https://github.com/quilljs/quill) for rich text support, it seems to be the safest and most widely utilized solution. It is made by Slab but used by Slack, Amazon, Microsoft, and more.