### PR TITLE
Enable Heroku hosting.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node dist/app.js

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
     "concurrently": "^5.1.0",
-    "dotenv": "^8.2.0",
     "eslint": "^6.8.0",
     "jest": "^25.1.0",
     "nodemon": "^2.0.2",
     "typescript": "^3.7.5"
   },
   "dependencies": {
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "firebase-admin": "^8.9.2",
     "http-status-codes": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gygb-backend-node",
   "version": "0.0.1",
   "description": "Backend for Get Your GreenBack Tompkins services.f",
-  "main": "src/server.ts",
+  "main": "src/app.ts",
   "license": "Apache-2.0",
   "scripts": {
     "serve": "node dist/app.js",
@@ -12,7 +12,7 @@
     "dev:test": "npm run test -- --watchAll",
     "test": "jest --forceExit --coverage --verbose",
     "lint": "tsc --noEmit && eslint \"src/**/*.ts\" --quiet --fix",
-    "debug": "node --inspect dist/server.js"
+    "debug": "node --inspect dist/app.js"
   },
   "devDependencies": {
     "@types/express": "^4.17.2",

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,16 @@
 import * as admin from "firebase-admin";
 
-export default admin.initializeApp({
-  projectId: process.env.FIREBASE_PROJECT_ID
+let cert = null;
+
+if (process.env.FIREBASE_CREDENTIALS) {
+  const keyfile = JSON.parse(process.env.FIREBASE_CREDENTIALS);
+
+  cert = admin.credential.cert(keyfile);
+}
+
+const app = admin.initializeApp({
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  credential: cert
 });
+
+export default app;


### PR DESCRIPTION
- Correct production dependencies.
- Adjust Firebase initialization to support file-less initialization. 
- Add `Procfile` to run heroku dyno.