### PR TITLE
Only add winner if non-null/undefined.

### DIFF
--- a/src/v1/quiz/db.ts
+++ b/src/v1/quiz/db.ts
@@ -341,7 +341,7 @@ export class QuizDB {
   async newRaffle(prize: string, requirement: number): Promise<string> {
     const { quizId } = this;
 
-    if (await this.getCurrentRaffle()) {
+    if (await this.getCurrentRaffle(false)) {
       throw new Error("A raffle already exists!");
     }
 

--- a/src/v1/quiz/models/raffle.ts
+++ b/src/v1/quiz/models/raffle.ts
@@ -72,12 +72,18 @@ export class Raffle extends Model {
 
   toDatastore(): RaffleDoc {
     const { prize, requirement, month, winner } = this;
-    return {
-      prize,
-      requirement,
-      winner,
-      month: firebase.firestore.Timestamp.fromDate(month)
-    };
+    return winner
+      ? {
+          prize,
+          requirement,
+          winner,
+          month: firebase.firestore.Timestamp.fromDate(month)
+        }
+      : {
+          prize,
+          requirement,
+          month: firebase.firestore.Timestamp.fromDate(month)
+        };
   }
 
   static fromDatastore(id: string, data: RaffleDoc): Raffle {


### PR DESCRIPTION
* Avoid caching raffle edit updates.
* Only add winner field to datastore when it is defined.