### PR TITLE
Basic fix for migration breakage.

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -29,16 +29,10 @@ export abstract class MigratableDB {
 
     for (let x = versionFrom + 1; x <= versionTo; x++) {
       console.log(
-        `Migrating ${db.constructor.name} from ${versionFrom} to ${versionTo}...`
+        `Migrating ${this.constructor.name} to version ${x}...`
       );
       await this.migrateHook(x);
     }
-
-    await db.meta().doc("db-info").set({
-      currentVersion: versionTo,
-    });
-
-    console.log(`Migration from ${versionFrom} to ${versionTo} complete.`);
   }
 }
 
@@ -51,6 +45,21 @@ export class GreenBackDB {
 
   get raw() {
     return this._db;
+  }
+
+  async finishMigrations() {
+    const versionTo = await this.apiVersion();
+    const versionFrom = await this.currentVersion();
+
+    await this.meta().doc("db-info").set({
+      currentVersion: versionTo,
+    });
+  
+    if (versionFrom !== versionTo) {
+      console.log(`Migration from ${versionFrom} to ${versionTo} complete.`);
+    } else {
+      console.log(`Initialized with API v${versionTo}`);
+    }
   }
 
   async currentVersion(): Promise<number> {

--- a/src/v1/routes.ts
+++ b/src/v1/routes.ts
@@ -17,5 +17,9 @@ export default async function defineRoutes(db: GreenBackDB, auth: express.Reques
   app.use("/tos/", await tosRoutes(db, auth));
   app.use("/admin/", await adminRoutes(auth));
 
+  // After all routes are defined, migrations should be complete.
+  // If a migration failed, it should have thrown an error which would prevent this code from calling.
+  db.finishMigrations();
+
   return app;
 }

--- a/src/v1/routes.ts
+++ b/src/v1/routes.ts
@@ -19,7 +19,7 @@ export default async function defineRoutes(db: GreenBackDB, auth: express.Reques
 
   // After all routes are defined, migrations should be complete.
   // If a migration failed, it should have thrown an error which would prevent this code from calling.
-  db.finishMigrations();
+  await db.finishMigrations();
 
   return app;
 }


### PR DESCRIPTION
- If we have multiple migrations at once, allow them to all run.