### PR TITLE
Tighten CORS for release.

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -76,6 +76,17 @@ export class GreenBackDB {
     return 2;
   }
 
+  async corsWhitelist(): Promise<string[]> {
+    const config = await this.meta().doc("site-config").get();
+
+    // Default to an empty whitelist if not setup.
+    if (!config.exists) {
+      return [];
+    }
+
+    return config.data().corsWhitelist || [];
+  }
+
   meta() {
     return this._db.collection(Collection.META);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,8 +13,20 @@ export default async function serve(db: GreenBackDB) {
   app.use(apiErrors);
   app.use(express.json());
 
-  app.use(cors({ origin: "*" }));
-  app.options("*", cors({ origin: "*" }));
+  const whitelist = await db.corsWhitelist();
+
+  const corsOptions: cors.CorsOptions = {
+    origin: (origin, callback) => {
+      if (whitelist.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("CORS: Invalid Origin!"));
+      }
+    }
+  };
+
+  app.use(cors(corsOptions));
+  app.options("*", cors(corsOptions));
 
   const auth = initializeAuth();
 


### PR DESCRIPTION
Prevent unintended cross-origin requests to our API by pulling the CORS whitelist from the backend.

- [x] Ensure this doesn't break iOS API calls (@ashneeldas2)
- [x] Test with deployed site

Pre-Release:

- [x] Add admin _and_ user domains to the whitelist.
