### PR TITLE
Use less restrictive cors for APIs targeting apps.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,22 +13,9 @@ export default async function serve(db: GreenBackDB) {
   app.use(apiErrors);
   app.use(express.json());
 
-  const whitelist = await db.corsWhitelist();
-
-  const corsOptions: cors.CorsOptions = {
-    origin: (origin, callback) => {
-      if (whitelist.includes(origin)) {
-        callback(null, true);
-      } else {
-        callback(new Error("CORS: Invalid Origin!"));
-      }
-    }
-  };
-
-  app.use(cors(corsOptions));
-  app.options("*", cors(corsOptions));
-
   const auth = initializeAuth();
+
+  app.use(cors());
 
   app.use("/v1/", await v1(db, auth));
 

--- a/src/v1/admin/routes.ts
+++ b/src/v1/admin/routes.ts
@@ -4,6 +4,7 @@ import * as Status from "http-status-codes";
 import { asyncify } from "../../middleware/async";
 
 import { AuthDB } from "../../middleware/auth/db";
+import cors, { CorsOptions } from "cors";
 
 function hasEmail(x: unknown): x is { email: string } {
   const asEmail = x as { email: string };
@@ -11,8 +12,11 @@ function hasEmail(x: unknown): x is { email: string } {
   return typeof x === "object" && "email" in asEmail && typeof asEmail.email === "string";
 }
 
-export default async function defineRoutes(auth: express.RequestHandler): Promise<express.Router> {
+export default async function defineRoutes(auth: express.RequestHandler, corsOptions: CorsOptions): Promise<express.Router> {
   const router = express.Router();
+
+  router.options("*", cors(corsOptions));
+  router.use(cors(corsOptions));
 
   router.use(auth);
 

--- a/src/v1/quiz/routes.ts
+++ b/src/v1/quiz/routes.ts
@@ -11,6 +11,7 @@ import { V1DB } from "../db";
 import { registerQuizDB } from "./db";
 import { Question, isQuestionEdit } from "./models/question";
 import { Quiz, isQuizEdit } from "./models/quiz";
+import cors, { CorsOptions } from "cors";
 
 function isAnswerMap(obj: unknown): obj is { [key: string]: number } {
   return (
@@ -22,6 +23,7 @@ function isAnswerMap(obj: unknown): obj is { [key: string]: number } {
 
 export default async function defineRoutes(
   db: V1DB,
+  corsOptions: CorsOptions,
   auth: express.RequestHandler
 ): Promise<express.Router> {
   const quizdb = registerQuizDB(db, "web-client");
@@ -35,6 +37,9 @@ export default async function defineRoutes(
   }
 
   function setupAuthenticated(authenticated: express.Router) {
+    authenticated.options("*", cors(corsOptions));
+    authenticated.use(cors(corsOptions));
+
     // Enable authentication
     authenticated.use(auth);
 
@@ -257,6 +262,9 @@ export default async function defineRoutes(
   }
 
   function setupUnauthenticated(unauthenticated: express.Router) {
+    unauthenticated.options("*", cors(corsOptions));
+    unauthenticated.use(cors(corsOptions));
+
     unauthenticated.get(
       "/web-client/tutorial",
       asyncify(async (_, res) => {

--- a/src/v1/routes.ts
+++ b/src/v1/routes.ts
@@ -1,4 +1,5 @@
 import * as express from "express";
+import cors from "cors";
 
 import { GreenBackDB } from "../db";
 
@@ -11,11 +12,23 @@ import adminRoutes from "./admin/routes";
 export default async function defineRoutes(db: GreenBackDB, auth: express.RequestHandler) {
   const app = express.Router();
 
-  app.use("/user/", await userRoutes(db, auth));
-  app.use("/quiz/", await quizRoutes(db, auth));
+  const whitelist = await db.corsWhitelist();
+
+  const corsOptions: cors.CorsOptions = {
+    origin: (origin, callback) => {
+      if (whitelist.includes(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("CORS: Invalid Origin!"));
+      }
+    }
+  };
+
+  app.use("/user/", await userRoutes(db, corsOptions, auth));
+  app.use("/quiz/", await quizRoutes(db, corsOptions, auth));
   app.use("/session/", await sessionRoutes(db, auth));
   app.use("/tos/", await tosRoutes(db, auth));
-  app.use("/admin/", await adminRoutes(auth));
+  app.use("/admin/", await adminRoutes(auth, corsOptions));
 
   // After all routes are defined, migrations should be complete.
   // If a migration failed, it should have thrown an error which would prevent this code from calling.


### PR DESCRIPTION
APIs which aren't exclusively serving web content should continue using a more permissive CORS configuration.

@ashneeldas2 this should fix the issues with the iPad app.